### PR TITLE
Include morph targets in export

### DIFF
--- a/crates/gltf_kun/src/io/format/gltf/export.rs
+++ b/crates/gltf_kun/src/io/format/gltf/export.rs
@@ -389,11 +389,11 @@ pub fn export(graph: &mut Graph, doc: &GltfDocument) -> Result<GltfFormat, GltfE
                         .map(|idx| Index::new(*idx as u32));
 
                     let targets = p
-                        .morph_targets(&graph)
+                        .morph_targets(graph)
                         .iter()
                         .map(|target| {
                             let attributes = target
-                                .attributes(&graph)
+                                .attributes(graph)
                                 .iter()
                                 .filter_map(|(k, v)| {
                                     accessor_idxs

--- a/crates/gltf_kun/src/io/format/gltf/export.rs
+++ b/crates/gltf_kun/src/io/format/gltf/export.rs
@@ -406,7 +406,8 @@ pub fn export(graph: &mut Graph, doc: &GltfDocument) -> Result<GltfFormat, GltfE
                                 normals: attributes.get(&Semantic::Normals).copied(),
                                 tangents: attributes.get(&Semantic::Tangents).copied(),
                             }
-                        }).collect::<Vec<_>>();
+                        })
+                        .collect::<Vec<_>>();
 
                     gltf::json::mesh::Primitive {
                         attributes,
@@ -882,8 +883,12 @@ mod tests {
         assert_eq!(result.json.materials.len(), 1);
         assert_eq!(result.json.meshes.len(), 1);
         assert_eq!(result.json.meshes[0].primitives.len(), 1);
-        assert!(result.json.meshes[0].primitives[0].targets
-            .as_ref().is_some_and(|target_vec| target_vec.len() == 1));
+        assert!(
+            result.json.meshes[0].primitives[0]
+                .targets
+                .as_ref()
+                .is_some_and(|target_vec| target_vec.len() == 1)
+        );
         assert_eq!(result.json.nodes.len(), 1);
         assert_eq!(result.json.samplers.len(), 1);
         assert_eq!(result.json.scenes.len(), 1);

--- a/crates/gltf_kun/src/io/format/gltf/export.rs
+++ b/crates/gltf_kun/src/io/format/gltf/export.rs
@@ -816,6 +816,7 @@ mod tests {
 
     use crate::graph::gltf::{
         Accessor, Buffer, Image, Material, Mesh, Node, Primitive, Scene, Texture,
+        primitive::MorphTarget,
     };
 
     use super::*;

--- a/crates/gltf_kun/src/io/format/gltf/export.rs
+++ b/crates/gltf_kun/src/io/format/gltf/export.rs
@@ -849,6 +849,9 @@ mod tests {
         primitive.set_indices(&mut graph, Some(accessor));
         primitive.set_material(&mut graph, Some(material));
 
+        let morph = primitive.create_morph_target(&mut graph, 0);
+        morph.set_attribute(&mut graph, Semantic::Positions, Some(accessor));
+
         let node = doc.create_node(&mut graph);
         node.set_mesh(&mut graph, Some(mesh));
 
@@ -864,6 +867,7 @@ mod tests {
         let _ = Texture::new(&mut graph);
         let _ = Material::new(&mut graph);
         let _ = Mesh::new(&mut graph);
+        let _ = MorphTarget::new(&mut graph);
         let _ = Primitive::new(&mut graph);
         let _ = Node::new(&mut graph);
         let _ = Scene::new(&mut graph);
@@ -876,6 +880,9 @@ mod tests {
         assert_eq!(result.json.images.len(), 1);
         assert_eq!(result.json.materials.len(), 1);
         assert_eq!(result.json.meshes.len(), 1);
+        assert_eq!(result.json.meshes[0].primitives.len(), 1);
+        assert!(result.json.meshes[0].primitives[0].targets
+            .as_ref().is_some_and(|target_vec| target_vec.len() == 1));
         assert_eq!(result.json.nodes.len(), 1);
         assert_eq!(result.json.samplers.len(), 1);
         assert_eq!(result.json.scenes.len(), 1);


### PR DESCRIPTION
This seems to me like a fairly simple oversight, I've duplicated the code for parsing attributes of the mesh primitives, and I've used it to add the morph targets during export. In the export test I've also added a section to test for the presence of the morph target.

TEXCOORD_n and COLOR_n morph target attributes are currently not supported by gltf_json ([tracking issue here](https://github.com/gltf-rs/gltf/issues/432)), but personally my current use case doesn't include these attributes so it can wait until that issue is resolved.